### PR TITLE
Implements Student Page Card Display for Template

### DIFF
--- a/components/molecules/LearningContentCard.tsx
+++ b/components/molecules/LearningContentCard.tsx
@@ -72,9 +72,14 @@ const LearningContentCard = ({
     setComponentLoading(false);
   };
   return (
-    <Card shadow={'sm'} radius={'md'} ref={ref}>
+    <Card
+      shadow={'sm'}
+      radius={'md'}
+      ref={ref}
+      style={{ padding: '36px 28px' }}
+    >
       <CustomLoadingOverlay visible={componentLoading} />
-      <Stack spacing={'xl'}>
+      <Stack spacing={'xl'} style={{ padding: '36px 28px' }}>
         <Group position={'apart'}>
           <Title order={3}>{page.learning_content?.title}</Title>
           {role_name === 'teacher' ? (

--- a/components/molecules/PracticeTestCard.tsx
+++ b/components/molecules/PracticeTestCard.tsx
@@ -80,9 +80,14 @@ const PracticeTestCard = ({ page, updatePageList }: practiceTestCardProps) => {
     setComponentLoading(false);
   };
   return (
-    <Card shadow={'sm'} radius={'md'} ref={ref}>
+    <Card
+      shadow={'sm'}
+      radius={'md'}
+      ref={ref}
+      style={{ padding: '36px 28px' }}
+    >
       <CustomLoadingOverlay visible={componentLoading} />
-      <Stack spacing={'xl'}>
+      <Stack spacing={'xl'} style={{ padding: '36px 28px' }}>
         <Group position={'apart'}>
           <Title order={3}>
             Prueba de Práctica: {page.practice_test?.title}

--- a/components/molecules/StudentTemplateCard.tsx
+++ b/components/molecules/StudentTemplateCard.tsx
@@ -2,21 +2,27 @@ import { Button, Card, Center, Image, Stack, Text, Title } from '@mantine/core';
 import { useRouter } from 'next/router';
 import studentTemplateCardProps from '../../types/component_schemas/studentTemplateCardProps';
 
-const StudentTemplateCard = ({ template }: studentTemplateCardProps) => {
+const StudentTemplateCard = ({
+  template,
+  displayNavigationButton,
+  displayHeaderImage,
+}: studentTemplateCardProps) => {
   const router = useRouter();
   return (
     <Card shadow={'sm'} radius={'md'} style={{ padding: '36px 28px' }}>
-      <Card.Section>
-        <Center>
-          <Image
-            src={template.image_url}
-            withPlaceholder
-            alt={`Representative Image for: ${template.title}`}
-            style={{ maxWidth: '450px', minHeight: '100px' }}
-            height={template.title ? 200 : undefined}
-          />
-        </Center>
-      </Card.Section>
+      {displayHeaderImage ? (
+        <Card.Section>
+          <Center>
+            <Image
+              src={template.image_url}
+              withPlaceholder
+              alt={`Representative Image for: ${template.title}`}
+              style={{ maxWidth: '450px', minHeight: '100px' }}
+              height={template.title ? 200 : undefined}
+            />
+          </Center>
+        </Card.Section>
+      ) : null}
       <Stack
         spacing={'xl'}
         justify={'center'}
@@ -29,16 +35,18 @@ const StudentTemplateCard = ({ template }: studentTemplateCardProps) => {
         <Text style={{ width: '100%' }} align={'left'}>
           {template.description}
         </Text>
-        <Button
-          onClick={() => {
-            router.push(`/student/template/${template.id}`);
-          }}
-          color={'dark'}
-          radius={'md'}
-          size={'lg'}
-        >
-          Revisar Tópico
-        </Button>
+        {displayNavigationButton ? (
+          <Button
+            onClick={() => {
+              router.push(`/student/template/${template.id}`);
+            }}
+            color={'dark'}
+            radius={'md'}
+            size={'lg'}
+          >
+            Revisar Tópico
+          </Button>
+        ) : null}
       </Stack>
     </Card>
   );

--- a/components/organisms/StudentTemplateCardDisplay.tsx
+++ b/components/organisms/StudentTemplateCardDisplay.tsx
@@ -38,7 +38,12 @@ const StudentTemplateCardDisplay = ({
   return (
     <CardHolder>
       {templateList.map((template) => (
-        <StudentTemplateCard key={template.id} template={template} />
+        <StudentTemplateCard
+          key={template.id}
+          template={template}
+          displayHeaderImage
+          displayNavigationButton
+        />
       ))}
     </CardHolder>
   );

--- a/pages/student/template/[templateID]/index.tsx
+++ b/pages/student/template/[templateID]/index.tsx
@@ -1,8 +1,50 @@
 import type { NextPage } from 'next';
 import type { GetServerSidePropsContext } from 'next';
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+import NonSSRWrapper from '../../../../components/overlays/NonSSRWrapper';
+import axiosInstance from '../../../../lib/constants/axiosInstance';
+import ShowFailedNotification from '../../../../lib/utils/ShowFailedNotification';
+import template from '../../../../types/api_schemas/template';
+import TemplatePageDisplay from '../../../../components/organisms/TemplatePageDisplay';
+import CardHolder from '../../../../components/templates/CardHolder';
+import StudentTemplateCard from '../../../../components/molecules/StudentTemplateCard';
 
 const Template: NextPage = () => {
-  return <h1>Template Screen</h1>;
+  const router = useRouter();
+  const { templateID } = router.query;
+  const [loading, setLoading] = useState<boolean>(false);
+  const [currentTemplate, setCurrentTemplate] = useState<template>();
+  const fetchTemplate = () => {
+    const inner_function = async () => {
+      setLoading(true);
+      try {
+        const { data } = await axiosInstance.get(`/templates/${templateID}`);
+        setCurrentTemplate(data.data);
+      } catch (error: any) {
+        ShowFailedNotification(
+          'Error al cargar el template',
+          'Error obteniendo la información del template. Intente nuevamente.'
+        );
+      }
+      setLoading(false);
+    };
+    inner_function();
+  };
+  useEffect(fetchTemplate, [templateID]);
+  return (
+    <NonSSRWrapper>
+      <CardHolder>
+        {currentTemplate ? (
+          <StudentTemplateCard template={currentTemplate} displayHeaderImage />
+        ) : null}
+        <TemplatePageDisplay
+          currentTemplate={currentTemplate}
+          loading={loading}
+        />
+      </CardHolder>
+    </NonSSRWrapper>
+  );
 };
 
 export async function getServerSideProps(context: GetServerSidePropsContext) {

--- a/types/component_schemas/studentTemplateCardProps.ts
+++ b/types/component_schemas/studentTemplateCardProps.ts
@@ -2,6 +2,8 @@ import template from '../api_schemas/template';
 
 type studentTemplateCardProps = {
   template: template;
+  displayNavigationButton?: boolean;
+  displayHeaderImage?: boolean;
 };
 
 export default studentTemplateCardProps;


### PR DESCRIPTION
Implements the View for displaying all of the Pages (LC and Tests) in a Template for Students

<a href="https://gitpod.io/#https://github.com/Xanth-64/FrontEnd-SHA/pull/35"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

