### PR TITLE
Implements Token Refresh Logic on the FrontEnd

### DIFF
--- a/components/molecules/LoginModal.tsx
+++ b/components/molecules/LoginModal.tsx
@@ -47,6 +47,7 @@ const LoginModal = (props: ModalProps) => {
               setCookie('idToken', response.data.data.idToken, {
                 maxAge: response.data.data.expiresIn,
               });
+              setCookie('refreshToken', response.data.data.refreshToken);
               await mutate('current_user/');
               router.push(`${user?.role[0].role_name}`);
               return;

--- a/components/molecules/SignupModal.tsx
+++ b/components/molecules/SignupModal.tsx
@@ -68,6 +68,7 @@ const SignupModal = (props: SignupModalProps) => {
               setCookie('idToken', response.data.data.idToken, {
                 maxAge: response.data.data.expiresIn,
               });
+              setCookie('refreshToken', response.data.data.refreshToken);
               await mutate('current_user/');
               if (user) {
                 router.push(`/${user?.role[0].role_name}`);


### PR DESCRIPTION
- Implements on 401 or 500 Error to try to refresh the current idToken
- Changes DeAuth condition to trigger when token refresh fails (or if there is no refreshToken) 

<a href="https://gitpod.io/#https://github.com/Xanth-64/FrontEnd-SHA/pull/43"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

